### PR TITLE
avoid erroneously hiding new plan comments

### DIFF
--- a/actions/plan/hide-old-comment.sh
+++ b/actions/plan/hide-old-comment.sh
@@ -16,7 +16,7 @@ if [ "${COMMENTS_URL}" == "" ]; then
 	exit 0
 fi
 
-SEARCH_TERM="${ENVIRONMENT} terraform plan"
+SEARCH_TERM="<b>${ENVIRONMENT} terraform plan</b>"
 PREVIOUS_COMMENT_ID=$(curl \
 	--silent \
 	--fail \


### PR DESCRIPTION
currently, if both `globaldev` and `dev` have new plans and run in that order, comment for `globaldev` would be hidden.