### PR TITLE
add support for setting tfvars in reusable workflow

### DIFF
--- a/actions/configure/configure.sh
+++ b/actions/configure/configure.sh
@@ -27,6 +27,7 @@ D2L_TF_CONFIG=$(jq -cr \
 	--arg role_arn "${ROLE_ARN}" \
 	'.[$envconfig.environment] = $envconfig
 	| .[$envconfig.environment].provider_role_arn = $role_arn
+	| .[$envconfig.environment].variables = {}
 	' \
 	<<< "${D2L_TF_CONFIG}"
 )

--- a/actions/configure/parse/parse.sh
+++ b/actions/configure/parse/parse.sh
@@ -16,7 +16,8 @@ echo "${CONFIG}" \
 			"provider_role_arn_rw": $account.provider_role_arn_rw,
 			"provider_role_tfvar": $tfvar,
 			"environment": .environment,
-			"workspace_path": .path
+			"workspace_path": .path,
+			"variables": .variables
 		}' \
 	 	- \
 	| xargs -d'\n' -I{} env ENVCONFIG='{}' "${HERE}/../configure.sh"

--- a/actions/plan/action.yml
+++ b/actions/plan/action.yml
@@ -40,6 +40,11 @@ runs:
       run: |
         echo "::set-output name=artifacts_dir::$(mktemp -d)"
 
+    - run: ${{ github.action_path }}/set-tfvars.py
+      shell: python
+      env:
+        VARIABLES: ${{ toJson(fromJson(inputs.config).variables) }}
+
     - id: plan
       working-directory: ${{ fromJson(inputs.config).workspace_path }}
       run: ${{ github.action_path }}/plan.sh

--- a/actions/plan/set-tfvars.py
+++ b/actions/plan/set-tfvars.py
@@ -1,0 +1,16 @@
+import json
+from os import environ
+
+GITHUB_ENV_PATH = environ.get('GITHUB_ENV')
+
+variables = json.loads(environ.get('VARIABLES'))
+
+with open(GITHUB_ENV_PATH, 'a', encoding="utf-8") as env_file:
+	env_file.write('\n')
+
+	for name, value in variables.items():
+		env_file.write('TF_VAR_')
+		env_file.write(name)
+		env_file.write('=')
+		env_file.write(value)
+		env_file.write('\n')


### PR DESCRIPTION
Expecting something like this to work:

```yaml
  terraform:
    uses: Brightspace/terraform-workflows/.github/workflows/workflow.yml@v3
    secrets: inherit
    with:
      terraform_version: 1.2.5
      config: |
        - provider_role_arn_ro: "arn:aws:iam::12345:role/terraform-plan"
          provider_role_arn_rw: "arn:aws:iam::54321:role/terraform-apply"
          workspaces:
            - environment: dev/ca-central-1
              path: terraform/environments/dev/ca-central-1
              variables:
                FOO: BAR
```