### PR TITLE
truncate plans that are too long for github comments

### DIFF
--- a/actions/plan/comment.sh
+++ b/actions/plan/comment.sh
@@ -22,6 +22,10 @@ if [ "${HAS_CHANGES}" == "false" ]; then
 fi
 
 PLAN_TEXT=$(terraform show "${ARTIFACTS_DIR}/terraform.plan" -no-color | sed --silent '/Terraform will perform the following actions/,$p')
+if [ "${PLAN_TEXT:0:60000}" != "${PLAN_TEXT}" ]; then
+	NEWLINE=$'\n'
+	PLAN_TEXT="${PLAN_TEXT:0:60000}${NEWLINE}${NEWLINE}-- Plan is truncated.  See build log for full plan. --"
+fi
 
 GITHUB_COMMENT_TEXT=$(mktemp)
 cat << EOF > "${GITHUB_COMMENT_TEXT}"


### PR DESCRIPTION
Adding sp-south-1 to brightspace-aws-logging is creating a very large terraform plan.  This change allows plans larger than the maximum github comment size.

job failing without truncation: https://github.com/Brightspace/brightspace-aws-logging/actions/runs/3100202191/jobs/5020219810
truncated comment: https://github.com/Brightspace/brightspace-aws-logging/pull/2017#issuecomment-1256254633
