### PR TITLE
format: checkout head_ref

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,6 +24,8 @@ jobs:
           terraform_version: ${{ inputs.terraform_version }}
           terraform_wrapper: false
       - uses: Brightspace/third-party-actions@actions/checkout
+        with:
+          ref: ${{ github.head_ref || github.ref }}
       - name: format
         working-directory: ${{ inputs.base_path }}
         id: format


### PR DESCRIPTION
On a PR event, the default ref that gets checked out is one that's merged with the base branch of the PR. Modifications made based on that ref includes new changes from the base branch, which can lead to confusing git history and unexpected changes in the auto formatting PR.

`github.head_ref` is the unmodified head branch on the PR, which is probably more intuitive for users.