### PR TITLE
Increase timeout for apply step

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,6 +27,11 @@ on:
         required: true
         type: string
 
+      apply_timeout:
+        required: false
+        default: 60
+        type: number
+
     outputs:
       had_changes:
         value: ${{ jobs.collect.outputs.has_changes }}
@@ -107,7 +112,7 @@ jobs:
   apply:
     name: Apply
     runs-on: [self-hosted, Linux, AWS]
-    timeout-minutes: 120
+    timeout-minutes: ${{ inputs.apply_timeout }}
 
     needs: collect
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -107,7 +107,7 @@ jobs:
   apply:
     name: Apply
     runs-on: [self-hosted, Linux, AWS]
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     needs: collect
 


### PR DESCRIPTION
Some AWS things take a really long time to apply, and while you can kind of march through it sometimes with multiple re-runs of the workflow (usually involving force unlocking state), doubling the amount of time should be enough.

I tried to make this an input, but while [the documentation](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability) says that you can use inputs for timeout-minutes, the validation schema doesn't like it:
![image](https://github.com/Brightspace/terraform-workflows/assets/586516/8bd12fae-692f-496e-9e6d-61da9ed000e5)
