### PR TITLE
make it easy to use auto provisioned Terraform roles

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - id: parse
-        uses: Brightspace/terraform-workflows/actions/configure/parse@v3
+        uses: Brightspace/terraform-workflows/actions/configure/parse@cbao/default-ace-role
         with:
           config: ${{ inputs.config }}
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - id: parse
-        uses: Brightspace/terraform-workflows/actions/configure/parse@cbao/default-ace-role
+        uses: Brightspace/terraform-workflows/actions/configure/parse@v3
         with:
           config: ${{ inputs.config }}
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The root of the YAML document should be an array of `Account` objects.
 
 ###### `Account.account_id` (`string`)
 
-**Optional**.
+**Recommended**.
 The 12 digit ID of the account where Terraform will be run.
 Required unless both `Account.provider_role_arn_ro` and `Account.provider_role_arn_rw` are provided (see below).
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and follow the steps below.
   * Enter the name of your main branch, e.g. `main`, and click `Add rule`.
 3. Save this environment by clicking `Save protection rules`.
 
-Now create an environment for each of your terraform envirionments/workspaces.
+Now create an environment for each of your terraform environments/workspaces.
 You do this by following the steps below, but use the terraform environment as the environment name.
 i.e. If your workspace is `terraform/environments/prod/ca-central-1`, name the environment `prod/ca-central-1`
 
@@ -87,8 +87,6 @@ data "archive_file" "lambda_package" {
 Now the Terraform workflow can be added to the repository.  Create the `.github/workflows/terraform.yml` in
 your repository with the following content.
 
-Within the content, the `provider_role_arn_{ro,rw}` specified will be the arn of the role, not just the role name.
-
 Each region that you have defined for your workflows will also need to be added as workspaces.  For example,
 in the content below, only `dev/us-east-1`, `prod/ca-central-1` and `prod/us-east-1` are defined.
 
@@ -112,15 +110,13 @@ jobs:
       terraform_version: 1.2.1
       config: |
         # Dev-Project Account
-        - provider_role_arn_ro: "{ terraform plan role in your dev account }"
-          provider_role_arn_rw: "{ terraform apply role in your dev account }"
+        - account_id: "{ your dev account ID }"
           workspaces:
             - environment: dev/us-east-1
               path: terraform/environments/dev/us-east-1
 
         # Prd-Project Account
-        - provider_role_arn_ro: "{ terraform plan role in your prod account }"
-          provider_role_arn_rw: "{ terraform apply role in your prod account }"
+        - account_id: "{ your prod account ID }"
           workspaces:
             - environment: prod/ca-central-1
               path: terraform/environments/prod/ca-central-1
@@ -137,17 +133,25 @@ The `config` input is a YAML string which describes your terraform workspaces.
 The workspaces are grouped by account in order to de-duplicate some shared settings for the common scenario of dev/prod accounts.
 The root of the YAML document should be an array of `Account` objects.
 
+###### `Account.account_id` (`string`)
+
+**Optional**.
+The 12 digit ID of the account where Terraform will be run.
+Required unless both `Account.provider_role_arn_ro` and `Account.provider_role_arn_rw` are provided (see below).
+
 ###### `Account.provider_role_arn_ro` (`string`)
 
-**Required**.
+**Optional**.
 The read-only role to use when performing terraform plans for pull requests in the account.
-Likely named `terraform-plan` and thus of the form `arn:aws:iam::{accountId}:role/terraform-plan`.
+Only needed if you do not wish to use the auto provisioned Terraform plan role.
+Required if `Account.account_id` isn't provided.
 
 ###### `Account.provider_role_arn_rw` (`string`)
 
-**Required**.
+**Optional**.
 The role to use when performing terraform plan and applies for merged pull requests in the account.
-Likely named `terraform-apply` and thus of the form `arn:aws:iam::{accountId}:role/terraform-apply`.
+Only needed if you do not wish to use the auto provisioned Terraform apply role.
+Required if `Account.account_id` isn't provided.
 
 ###### `Account.provider_role_tfvar` (`string`)
 
@@ -170,7 +174,7 @@ MUST be unique across all accounts and workspaces.
 ###### `Workspace.path` (`string`)
 
 **Required**.
-The path to the terraform workspace within your resository.
+The path to the terraform workspace within your repository.
 
 ###### `Workspace.provider_role_tfvar` (`string`)
 
@@ -183,7 +187,7 @@ Defaults to the configured account value else to `terraform_role_arn`.
 ##### `default_branch` (`string`)
 
 **Optional**.
-When running on the main branch, the workflow asserts that it is running on the latest commit so old builds aren't accidently re-run and applied.
+When running on the main branch, the workflow asserts that it is running on the latest commit so old builds aren't accidentally re-run and applied.
 If you run into this restriction when trying to revert to an old state by running an old build, you should open a PR reverting any source changes and merge that instead.
 Defaults to `main`.
 

--- a/actions/configure/action.yml
+++ b/actions/configure/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: true
 
   account_id:
-    description: AWS Account ID
+    description: AWS account ID
     required: false
 
   provider_role_arn_ro:

--- a/actions/configure/action.yml
+++ b/actions/configure/action.yml
@@ -10,13 +10,17 @@ inputs:
     description: Path to the terraform workspace
     required: true
 
+  account_id:
+    description: AWS Account ID
+    required: false
+
   provider_role_arn_ro:
     description: Role ARN to provide as a tfvar for PRs
-    required: true
+    required: false
 
   provider_role_arn_rw:
     description: Role ARN to provide as a tfvar post-merge
-    required: true
+    required: false
 
   provider_role_tfvar:
     descritpion: tfvar name to use when specifying the provider role ARN

--- a/actions/configure/configure.sh
+++ b/actions/configure/configure.sh
@@ -18,6 +18,10 @@ fi
 
 if [[ -z "$ROLE_ARN" ]]; then
 	ACCOUNT_ID=$(jq -r '.account_id' <<< "${ENVCONFIG}")
+	if [[ -z "$ACCOUNT_ID" ]]; then
+		echo '::error ::Either "account_id" or both of "provider_role_arn_ro" and "provider_role_arn_rw" must be provided'
+		exit 1
+	fi
 	SUFFIX=${GITHUB_REPOSITORY/'/'/+}
 	SUFFIX=${SUFFIX/#'BrightspaceHypermediaComponents'/'BHC'}
 	if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then

--- a/actions/configure/configure.sh
+++ b/actions/configure/configure.sh
@@ -19,7 +19,7 @@ fi
 if [[ -z "${ROLE_ARN}" ]]; then
 	ACCOUNT_ID=$(jq -r '.account_id' <<< "${ENVCONFIG}")
 	if [[ -z "${ACCOUNT_ID}" ]]; then
-		echo '::error ::Either "account_id" or both of "provider_role_arn_ro" and "provider_role_arn_rw" must be provided'
+		echo '::error::Either "account_id" or both of "provider_role_arn_ro" and "provider_role_arn_rw" must be provided'
 		exit 1
 	fi
 	SUFFIX=${GITHUB_REPOSITORY/'/'/+}

--- a/actions/configure/configure.sh
+++ b/actions/configure/configure.sh
@@ -16,9 +16,9 @@ else
 	ROLE_ARN=$(jq -r '.provider_role_arn_rw' <<< "${ENVCONFIG}")
 fi
 
-if [[ -z "$ROLE_ARN" ]]; then
+if [[ -z "${ROLE_ARN}" ]]; then
 	ACCOUNT_ID=$(jq -r '.account_id' <<< "${ENVCONFIG}")
-	if [[ -z "$ACCOUNT_ID" ]]; then
+	if [[ -z "${ACCOUNT_ID}" ]]; then
 		echo '::error ::Either "account_id" or both of "provider_role_arn_ro" and "provider_role_arn_rw" must be provided'
 		exit 1
 	fi

--- a/actions/configure/configure.sh
+++ b/actions/configure/configure.sh
@@ -16,6 +16,17 @@ else
 	ROLE_ARN=$(jq -r '.provider_role_arn_rw' <<< "${ENVCONFIG}")
 fi
 
+if [[ -z "$ROLE_ARN" ]]; then
+	ACCOUNT_ID=$(jq -r '.account_id' <<< "${ENVCONFIG}")
+	SUFFIX=${GITHUB_REPOSITORY/'/'/+}
+	SUFFIX=${SUFFIX/#'BrightspaceHypermediaComponents'/'BHC'}
+	if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+		ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/terraform/tfp+github+${SUFFIX}"
+	else
+		ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/terraform/tfa+github+${SUFFIX}"
+	fi
+fi
+
 D2L_TF_ENVS=$(jq -cr \
 	--argjson envconfig "${ENVCONFIG}" \
 	'. += [$envconfig.environment]

--- a/actions/configure/parse/parse.sh
+++ b/actions/configure/parse/parse.sh
@@ -4,6 +4,19 @@ set -euo pipefail
 
 export D2L_TF_CONFIGURE_TMP_DIR=$(mktemp -d)
 
+errors=$(echo "${CONFIG}" \
+	| yq -o=json . - \
+	| jq -cr '
+		.[]
+		| .account_id or (.provider_role_arn_ro and .provider_role_arn_rw)
+		| select(. | not)
+		| 1
+		')
+if [[ -n "${errors}" ]]; then
+	echo '::error::Either "account_id" or both of "provider_role_arn_ro" and "provider_role_arn_rw" must be provided'
+	exit 1
+fi
+
 role_suffix=${GITHUB_REPOSITORY/'/'/+}
 role_suffix=${role_suffix/#'BrightspaceHypermediaComponents'/'BHC'}
 
@@ -12,8 +25,8 @@ echo "${CONFIG}" \
 	| jq -cr '
 		.[]
 		| . as $account
-		| (.provider_role_arn_ro // "arn:aws:iam::\($account.account_id):role/terraform/tfp+github+'"${role_suffix}"'") as $provider_role_arn_ro
-		| (.provider_role_arn_rw // "arn:aws:iam::\($account.account_id):role/terraform/tfa+github+'"${role_suffix}"'") as $provider_role_arn_rw
+		| (.provider_role_arn_ro // "arn:aws:iam::\(.account_id):role/terraform/tfp+github+'"${role_suffix}"'") as $provider_role_arn_ro
+		| (.provider_role_arn_rw // "arn:aws:iam::\(.account_id):role/terraform/tfa+github+'"${role_suffix}"'") as $provider_role_arn_rw
 		| $account.workspaces[]
 		| (.provider_role_tfvar // $account.provider_role_tfvar // "terraform_role_arn") as $tfvar
 		| {

--- a/actions/configure/parse/parse.sh
+++ b/actions/configure/parse/parse.sh
@@ -22,6 +22,23 @@ echo "${CONFIG}" \
 			"provider_role_tfvar": $tfvar,
 			"environment": .environment,
 			"workspace_path": .path
+		}'
+
+echo "${CONFIG}" \
+	| yq -o=json . - \
+	| jq -cr '
+		.[]
+		| . as $account
+		| (.provider_role_arn_ro // "arn:aws:iam::\($account.account_id):role/terraform/tfp+github+'"${default_role_suffix}"'") as $provider_role_arn_ro
+		| (.provider_role_arn_rw // "arn:aws:iam::\($account.account_id):role/terraform/tfa+github+'"${default_role_suffix}"'") as $provider_role_arn_rw
+		| $account.workspaces[]
+		| (.provider_role_tfvar // $account.provider_role_tfvar // "terraform_role_arn") as $tfvar
+		| {
+			"provider_role_arn_ro": $provider_role_arn_ro,
+			"provider_role_arn_rw": $provider_role_arn_rw,
+			"provider_role_tfvar": $tfvar,
+			"environment": .environment,
+			"workspace_path": .path
 		}' \
 	 	- \
 	| xargs -d'\n' -I{} env ENVCONFIG='{}' "${HERE}/../configure.sh"

--- a/actions/configure/parse/parse.sh
+++ b/actions/configure/parse/parse.sh
@@ -22,23 +22,6 @@ echo "${CONFIG}" \
 			"provider_role_tfvar": $tfvar,
 			"environment": .environment,
 			"workspace_path": .path
-		}'
-
-echo "${CONFIG}" \
-	| yq -o=json . - \
-	| jq -cr '
-		.[]
-		| . as $account
-		| (.provider_role_arn_ro // "arn:aws:iam::\($account.account_id):role/terraform/tfp+github+'"${default_role_suffix}"'") as $provider_role_arn_ro
-		| (.provider_role_arn_rw // "arn:aws:iam::\($account.account_id):role/terraform/tfa+github+'"${default_role_suffix}"'") as $provider_role_arn_rw
-		| $account.workspaces[]
-		| (.provider_role_tfvar // $account.provider_role_tfvar // "terraform_role_arn") as $tfvar
-		| {
-			"provider_role_arn_ro": $provider_role_arn_ro,
-			"provider_role_arn_rw": $provider_role_arn_rw,
-			"provider_role_tfvar": $tfvar,
-			"environment": .environment,
-			"workspace_path": .path
 		}' \
 	 	- \
 	| xargs -d'\n' -I{} env ENVCONFIG='{}' "${HERE}/../configure.sh"

--- a/actions/configure/parse/parse.sh
+++ b/actions/configure/parse/parse.sh
@@ -4,16 +4,21 @@ set -euo pipefail
 
 export D2L_TF_CONFIGURE_TMP_DIR=$(mktemp -d)
 
+default_role_suffix=${GITHUB_REPOSITORY/'/'/+}
+default_role_suffix=${default_role_suffix/#'BrightspaceHypermediaComponents'/'BHC'}
+
 echo "${CONFIG}" \
 	| yq -o=json . - \
 	| jq -cr '
 		.[]
 		| . as $account
+		| (.provider_role_arn_ro // "arn:aws:iam::\($account.account_id):role/terraform/tfp+github+'"${default_role_suffix}"'") as $provider_role_arn_ro
+		| (.provider_role_arn_rw // "arn:aws:iam::\($account.account_id):role/terraform/tfa+github+'"${default_role_suffix}"'") as $provider_role_arn_rw
 		| $account.workspaces[]
-		| .provider_role_tfvar // $account.provider_role_tfvar // "terraform_role_arn" as $tfvar
+		| (.provider_role_tfvar // $account.provider_role_tfvar // "terraform_role_arn") as $tfvar
 		| {
-			"provider_role_arn_ro": $account.provider_role_arn_ro,
-			"provider_role_arn_rw": $account.provider_role_arn_rw,
+			"provider_role_arn_ro": $provider_role_arn_ro,
+			"provider_role_arn_rw": $provider_role_arn_rw,
 			"provider_role_tfvar": $tfvar,
 			"environment": .environment,
 			"workspace_path": .path

--- a/actions/configure/parse/parse.sh
+++ b/actions/configure/parse/parse.sh
@@ -4,16 +4,16 @@ set -euo pipefail
 
 export D2L_TF_CONFIGURE_TMP_DIR=$(mktemp -d)
 
-default_role_suffix=${GITHUB_REPOSITORY/'/'/+}
-default_role_suffix=${default_role_suffix/#'BrightspaceHypermediaComponents'/'BHC'}
+role_suffix=${GITHUB_REPOSITORY/'/'/+}
+role_suffix=${role_suffix/#'BrightspaceHypermediaComponents'/'BHC'}
 
 echo "${CONFIG}" \
 	| yq -o=json . - \
 	| jq -cr '
 		.[]
 		| . as $account
-		| (.provider_role_arn_ro // "arn:aws:iam::\($account.account_id):role/terraform/tfp+github+'"${default_role_suffix}"'") as $provider_role_arn_ro
-		| (.provider_role_arn_rw // "arn:aws:iam::\($account.account_id):role/terraform/tfa+github+'"${default_role_suffix}"'") as $provider_role_arn_rw
+		| (.provider_role_arn_ro // "arn:aws:iam::\($account.account_id):role/terraform/tfp+github+'"${role_suffix}"'") as $provider_role_arn_ro
+		| (.provider_role_arn_rw // "arn:aws:iam::\($account.account_id):role/terraform/tfa+github+'"${role_suffix}"'") as $provider_role_arn_rw
 		| $account.workspaces[]
 		| (.provider_role_tfvar // $account.provider_role_tfvar // "terraform_role_arn") as $tfvar
 		| {


### PR DESCRIPTION
The changes should be backward compatible.
Both the reusable workflow and the separate actions have been tested with both provided role arns & auto provisioned roles on Lrn-Vulcan in https://github.com/Brightspace/vulcan-scratch/pull/338.

Shouldn't merge until we're ready to roll out everything else though (mainly because of docs).