### PR TITLE
support for passing artifacts to plan and apply

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -93,7 +93,7 @@ jobs:
       uses: Brightspace/s3-artifact-actions/extract@master
       with:
         path: .artifacts
-        artifacts_url: inputs.artifacts_url
+        artifacts_url: ${{ inputs.artifacts_url }}
 
     - uses: Brightspace/terraform-workflows/actions/plan@v3
       with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -147,7 +147,7 @@ jobs:
       uses: Brightspace/s3-artifact-actions/extract@master
       with:
         path: .artifacts
-        artifacts_url: inputs.artifacts_url
+        artifacts_url: ${{ inputs.artifacts_url }}
 
     - uses: Brightspace/terraform-workflows/actions/apply@v3
       with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,6 +32,12 @@ on:
         default: 60
         type: number
 
+      artifacts_url:
+        description: Download an archive from the specified url and extract it under .artifacts in the root of the workspace
+        required: false
+        type: string
+        default: ""
+
     outputs:
       had_changes:
         value: ${{ jobs.collect.outputs.has_changes }}
@@ -82,6 +88,13 @@ jobs:
         remote: origin
         ref: ${{ inputs.default_branch }}
 
+    - if: ${{ inputs.artifacts_url != '' }}
+      name: 'Extract artifacts'
+      uses: Brightspace/s3-artifact-actions/extract@master
+      with:
+        path: .artifacts
+        artifacts_url: inputs.artifacts_url
+
     - uses: Brightspace/terraform-workflows/actions/plan@v3
       with:
         comment_plan: ${{ inputs.comment_plan }}
@@ -128,6 +141,13 @@ jobs:
 
     steps:
     - uses: Brightspace/third-party-actions@actions/checkout
+
+    - if: ${{ inputs.artifacts_url != '' }}
+      name: 'Extract artifacts'
+      uses: Brightspace/s3-artifact-actions/extract@master
+      with:
+        path: .artifacts
+        artifacts_url: inputs.artifacts_url
 
     - uses: Brightspace/terraform-workflows/actions/apply@v3
       with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -92,7 +92,7 @@ jobs:
       name: 'Extract artifacts'
       uses: Brightspace/s3-artifact-actions/extract@master
       with:
-        path: .artifacts
+        path: ${{ fromJson(needs.configure.outputs.config)[matrix.environment].workspace_path }}/.artifacts
         artifacts_url: ${{ inputs.artifacts_url }}
 
     - uses: Brightspace/terraform-workflows/actions/plan@v3
@@ -141,13 +141,6 @@ jobs:
 
     steps:
     - uses: Brightspace/third-party-actions@actions/checkout
-
-    - if: ${{ inputs.artifacts_url != '' }}
-      name: 'Extract artifacts'
-      uses: Brightspace/s3-artifact-actions/extract@master
-      with:
-        path: .artifacts
-        artifacts_url: ${{ inputs.artifacts_url }}
 
     - uses: Brightspace/terraform-workflows/actions/apply@v3
       with:


### PR DESCRIPTION
The main reason projects haven't been able to adopt the shared workflows is build artifacts that are deployed by terraform.
This adds support for an artifacts_url parameter where plan and apply steps will download and extract an archive from that url into a `.artifacts` folder in the default workspace path.

Here's an example of how this change would help storageable adopt the shared terraform workflow: https://github.com/Brightspace/storageable-terraform/pull/1258