### PR TITLE
Add option to skip archiving things in the 'plan' action

### DIFF
--- a/actions/plan/action.yml
+++ b/actions/plan/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: true
 
   skip_archive:
-    description: true/false. Whether to skip archiving the plan and artifacts. Please note that the 'collect' and 'plan' actions rely on things being archived.
+    description: true/false. Whether to skip archiving the plan and artifacts. Please note that the 'collect' and 'apply' actions rely on things being archived.
     default: false
 
   terraform_version:

--- a/actions/plan/action.yml
+++ b/actions/plan/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: true/false. Whether to do a refresh for PR plans.
     default: true
 
+  skip_archive:
+    description: true/false. Whether to skip archiving the plan and artifacts. Please note that the 'collect' action relies on things being archived.
+    default: false
+
   terraform_version:
     description: Which version of terraform to use
     required: true
@@ -66,6 +70,7 @@ runs:
         TERRAFORM_VERSION_INPUT: ${{ inputs.terraform_version }}
 
     - run: ${{ github.action_path }}/archive.sh
+      if: ${{ !inputs.skip_archive }}
       shell: bash
       env:
         ENVIRONMENT: ${{ fromJson(inputs.config).environment }}

--- a/actions/plan/action.yml
+++ b/actions/plan/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: true
 
   skip_archive:
-    description: true/false. Whether to skip archiving the plan and artifacts. Please note that the 'collect' action relies on things being archived.
+    description: true/false. Whether to skip archiving the plan and artifacts. Please note that the 'collect' and 'plan' actions rely on things being archived.
     default: false
 
   terraform_version:


### PR DESCRIPTION
This is for cases where 'Plan' action is used in jobs with other actions that can just get the terraform plan from the action output.

It also avoids an 'assume role' which can impede other 'assume role' calls further down in the same job.