### PR TITLE
add autoapply workflow

### DIFF
--- a/.github/workflows/workflow-autoapply.yml
+++ b/.github/workflows/workflow-autoapply.yml
@@ -41,7 +41,7 @@ on:
 
     outputs:
       had_changes:
-        value: ${{ toJson(jobs.plan.outputs.*) != '[]' }}
+        value: ${{ toJson(jobs.plan_apply.outputs.*) != '[]' }}
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/workflow-autoapply.yml
+++ b/.github/workflows/workflow-autoapply.yml
@@ -1,0 +1,183 @@
+name: Terraform
+
+on:
+  workflow_call:
+    inputs:
+      comment_plan:
+        description: Create a pull request comment of the plan in addition to adding it to the summary page
+        required: false
+        type: boolean
+        default: true
+
+      config:
+        description: A JSON (with comments) config string
+        required: true
+        type: string
+
+      default_branch:
+        required: false
+        type: string
+        default: main
+
+      refresh_on_pr:
+        required: false
+        type: boolean
+        default: true
+
+      terraform_version:
+        required: true
+        type: string
+
+      apply_timeout:
+        required: false
+        default: 60
+        type: number
+
+      artifacts_url:
+        description: Download an archive from the specified url and extract it under .artifacts in the root of the workspace
+        required: false
+        type: string
+        default: ""
+
+    outputs:
+      had_changes:
+        value: ${{ toJson(jobs.plan.outputs.*) != '[]' }}
+
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+
+jobs:
+  plan_apply:
+    name: Plan and Apply
+    runs-on: [self-hosted, Linux, AWS]
+    timeout-minutes: 60
+
+    environment: ${{ github.event_name != 'pull_request' && matrix.environment || null }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: ${{ fromJson(inputs.config).*.workspaces.*.environment }}
+
+    steps:
+    - id: parse
+      uses: Brightspace/terraform-workflows/actions/parse-config@v4
+      with:
+        # GHA's fromJson() supports comments in JSON strings which is nice from
+        # an end-user perspective (e.g. naming account ids). toJson(fromJson())
+        # is used in order to strip these comments out before parsing it ourselves
+        config: ${{ toJson(fromJson(inputs.config)) }}
+        max_environments: 50
+
+    - uses: Brightspace/third-party-actions@actions/checkout
+
+    - if: ${{ github.event_name != 'pull_request' }}
+      name: 'Assert: Branch is up to date'
+      uses: Brightspace/assert-git-remote-ref-action@main
+      with:
+        remote: origin
+        ref: ${{ inputs.default_branch }}
+
+    - if: ${{ inputs.artifacts_url != '' }}
+      name: 'Extract artifacts'
+      uses: Brightspace/s3-artifact-actions/extract@master
+      with:
+        path: ${{ fromJson(steps.parse.outputs.config)[matrix.environment].workspace_path }}/.artifacts
+        artifacts_url: ${{ inputs.artifacts_url }}
+
+    - id: plan
+      uses: Brightspace/terraform-workflows/actions/plan@v4
+      with:
+        comment_plan: ${{ inputs.comment_plan }}
+        config: ${{ toJson(fromJson(steps.parse.outputs.config)[matrix.environment]) }}
+        terraform_version: ${{ inputs.terraform_version }}
+        refresh_on_pr: ${{ inputs.refresh_on_pr }}
+        skip_archive: true
+
+    # Matrixed jobs overwrite eachother's outputs if they use the same name.
+    # Unfortunately though, job outputs need to be statically defined in the yml
+    # Step outputs are dynamic though, as well as the _population_ of job outputs
+    # (based on the existence of their configured value). This step uniquely maps
+    # the environment name to one of the statically defined outputs below. The
+    # apply job can then consume the sparse set of outputs that were assigned a
+    # value via `needs.plan.outputs.*`
+    - if: ${{ steps.plan.outputs.has_changes == 'true' }}
+      name: Mark as changed
+      id: changed
+      shell: bash
+      run: |
+        ENVIRONMENT_INDEX=$(jq -cr \
+          --arg environment "${ENVIRONMENT}" \
+          '
+            to_entries[]
+            | select(.value == $environment)
+            | .key
+          ' \
+          <<< "${ENVIRONMENTS}"
+        )
+        echo "changed_env_${ENVIRONMENT_INDEX}=${ENVIRONMENT}" >> "${GITHUB_OUTPUT}"
+      env:
+        ENVIRONMENTS: ${{ steps.parse.outputs.environments }}
+        ENVIRONMENT: ${{ matrix.environment }}
+
+    - if: github.event_name != 'pull_request' && steps.plan.outputs.has_changes == 'true'
+      name: Apply
+      shell: bash
+      run: |
+        terraform apply -input=false "${PLAN_PATH}"
+      env:
+        PLAN_PATH: ${{ steps.plan.outputs.plan_json_path }}
+
+    outputs:
+      changed_env_0: ${{ steps.changed.outputs.changed_env_0 }}
+      changed_env_1: ${{ steps.changed.outputs.changed_env_1 }}
+      changed_env_2: ${{ steps.changed.outputs.changed_env_2 }}
+      changed_env_3: ${{ steps.changed.outputs.changed_env_3 }}
+      changed_env_4: ${{ steps.changed.outputs.changed_env_4 }}
+      changed_env_5: ${{ steps.changed.outputs.changed_env_5 }}
+      changed_env_6: ${{ steps.changed.outputs.changed_env_6 }}
+      changed_env_7: ${{ steps.changed.outputs.changed_env_7 }}
+      changed_env_8: ${{ steps.changed.outputs.changed_env_8 }}
+      changed_env_9: ${{ steps.changed.outputs.changed_env_9 }}
+      changed_env_10: ${{ steps.changed.outputs.changed_env_10 }}
+      changed_env_11: ${{ steps.changed.outputs.changed_env_11 }}
+      changed_env_12: ${{ steps.changed.outputs.changed_env_12 }}
+      changed_env_13: ${{ steps.changed.outputs.changed_env_13 }}
+      changed_env_14: ${{ steps.changed.outputs.changed_env_14 }}
+      changed_env_15: ${{ steps.changed.outputs.changed_env_15 }}
+      changed_env_16: ${{ steps.changed.outputs.changed_env_16 }}
+      changed_env_17: ${{ steps.changed.outputs.changed_env_17 }}
+      changed_env_18: ${{ steps.changed.outputs.changed_env_18 }}
+      changed_env_19: ${{ steps.changed.outputs.changed_env_19 }}
+      changed_env_20: ${{ steps.changed.outputs.changed_env_20 }}
+      changed_env_21: ${{ steps.changed.outputs.changed_env_21 }}
+      changed_env_22: ${{ steps.changed.outputs.changed_env_22 }}
+      changed_env_23: ${{ steps.changed.outputs.changed_env_23 }}
+      changed_env_24: ${{ steps.changed.outputs.changed_env_24 }}
+      changed_env_25: ${{ steps.changed.outputs.changed_env_25 }}
+      changed_env_26: ${{ steps.changed.outputs.changed_env_26 }}
+      changed_env_27: ${{ steps.changed.outputs.changed_env_27 }}
+      changed_env_28: ${{ steps.changed.outputs.changed_env_28 }}
+      changed_env_29: ${{ steps.changed.outputs.changed_env_29 }}
+      changed_env_30: ${{ steps.changed.outputs.changed_env_30 }}
+      changed_env_31: ${{ steps.changed.outputs.changed_env_31 }}
+      changed_env_32: ${{ steps.changed.outputs.changed_env_32 }}
+      changed_env_33: ${{ steps.changed.outputs.changed_env_33 }}
+      changed_env_34: ${{ steps.changed.outputs.changed_env_34 }}
+      changed_env_35: ${{ steps.changed.outputs.changed_env_35 }}
+      changed_env_36: ${{ steps.changed.outputs.changed_env_36 }}
+      changed_env_37: ${{ steps.changed.outputs.changed_env_37 }}
+      changed_env_38: ${{ steps.changed.outputs.changed_env_38 }}
+      changed_env_39: ${{ steps.changed.outputs.changed_env_39 }}
+      changed_env_40: ${{ steps.changed.outputs.changed_env_40 }}
+      changed_env_41: ${{ steps.changed.outputs.changed_env_41 }}
+      changed_env_42: ${{ steps.changed.outputs.changed_env_42 }}
+      changed_env_43: ${{ steps.changed.outputs.changed_env_43 }}
+      changed_env_44: ${{ steps.changed.outputs.changed_env_44 }}
+      changed_env_45: ${{ steps.changed.outputs.changed_env_45 }}
+      changed_env_46: ${{ steps.changed.outputs.changed_env_46 }}
+      changed_env_47: ${{ steps.changed.outputs.changed_env_47 }}
+      changed_env_48: ${{ steps.changed.outputs.changed_env_48 }}
+      changed_env_49: ${{ steps.changed.outputs.changed_env_49 }}

--- a/.github/workflows/workflow-autoapply.yml
+++ b/.github/workflows/workflow-autoapply.yml
@@ -55,6 +55,8 @@ jobs:
     timeout-minutes: 60
 
     environment: ${{ github.event_name != 'pull_request' && matrix.environment || null }}
+    # Workflows against a branch run one-at-a-time, workflows against a PR are non-blocking
+    concurrency: ${{ matrix.environment }}/${{ github.event_name != 'pull_request' && github.ref || github.run_id }}
 
     strategy:
       fail-fast: false

--- a/actions/plan/action.yml
+++ b/actions/plan/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: true
 
   skip_archive:
-    description: true/false. Whether to skip archiving the plan and artifacts. Please note that the 'collect' and 'plan' actions rely on things being archived.
+    description: true/false. Whether to skip archiving the plan and artifacts. Please note that the 'collect' and 'apply' actions rely on things being archived.
     default: false
 
   terraform_version:

--- a/actions/plan/action.yml
+++ b/actions/plan/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: true/false. Whether to do a refresh for PR plans.
     default: true
 
+  skip_archive:
+    description: true/false. Whether to skip archiving the plan and artifacts. Please note that the 'collect' action relies on things being archived.
+    default: false
+
   terraform_version:
     description: Which version of terraform to use
     required: true
@@ -66,6 +70,7 @@ runs:
         TERRAFORM_VERSION_INPUT: ${{ inputs.terraform_version }}
 
     - run: ${{ github.action_path }}/archive.sh
+      if: ${{ !inputs.skip_archive }}
       shell: bash
       env:
         ENVIRONMENT: ${{ fromJson(inputs.config).environment }}

--- a/actions/plan/action.yml
+++ b/actions/plan/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: true
 
   skip_archive:
-    description: true/false. Whether to skip archiving the plan and artifacts. Please note that the 'collect' and 'apply' actions rely on things being archived.
+    description: true/false. Whether to skip archiving the plan and artifacts
     default: false
 
   terraform_version:

--- a/actions/plan/action.yml
+++ b/actions/plan/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: true
 
   skip_archive:
-    description: true/false. Whether to skip archiving the plan and artifacts. Please note that the 'collect' action relies on things being archived.
+    description: true/false. Whether to skip archiving the plan and artifacts. Please note that the 'collect' and 'plan' actions rely on things being archived.
     default: false
 
   terraform_version:


### PR DESCRIPTION
While we generally want approvals - we do have more than a few "pipeline" jobs which go through without - it would be good for those to be standardized and optimized to run on one job.

Definitely don't want it to be reached for willy nilly though. Not putting it in the README.

Should I also rename it to `workflow-autoapply-iliketolivedangerously.yml`?