### PR TITLE
query employee by their GitHub user ID

### DIFF
--- a/actions/plan/slack/get-slack-username.sh
+++ b/actions/plan/slack/get-slack-username.sh
@@ -15,9 +15,9 @@ AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' <<< "${ASSUMEROLE_RESULT}"
 D2L_EMAIL=$(aws dynamodb query \
 	--region ca-central-1 \
 	--table-name D2LEmployees \
-	--index-name GitHubUserIndex \
-	--key-condition-expression "GitHubUser = :name" \
-	--expression-attribute-values "{\":name\": {\"S\": \"${GITHUB_ACTOR}\"}}" \
+	--index-name GitHubUserIdIndex \
+	--key-condition-expression "GitHubUserId = :u" \
+	--expression-attribute-values "{\":u\": {\"N\": \"${GITHUB_ACTOR_ID}\"}}" \
 	--query 'Items[].D2LEmail.S' \
 	--output text)
 


### PR DESCRIPTION
GitHub usernames are case-insensitive, so querying on the username hasn't been very reliable.
See https://d2l.slack.com/archives/C03ADT41M19/p1732729705645029?thread_ts=1732729566.973369&cid=C03ADT41M19

Related: https://github.com/Brightspace/d2l.dev/pull/5542