### PR TITLE
OIDC

### DIFF
--- a/.github/workflows/workflow-autoapply.yml
+++ b/.github/workflows/workflow-autoapply.yml
@@ -133,7 +133,7 @@ jobs:
       name: Assume Hub Role
       uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
       with:
-        role-to-assume: arn:aws:iam::323258989788:role/hub-roles/github+${{ github.repository_owner }}+${{ github.event.repository.name }}+repo
+        role-to-assume: arn:aws:iam::323258989788:role/hub-roles/github+${{ github.repository_owner }}+${{ github.event.repository.name }}+tfapply
         aws-region: us-east-1
 
     - id: plan

--- a/.github/workflows/workflow-autoapply.yml
+++ b/.github/workflows/workflow-autoapply.yml
@@ -52,12 +52,6 @@ on:
         value: ${{ toJson(jobs.plan_apply.outputs.*) != '[]' }}
 
     secrets:
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      AWS_SESSION_TOKEN:
-        required: true
       ARTIFACT_REPOSITORIES_SECRET_1:
         required: false
       ARTIFACT_REPOSITORIES_SECRET_2:
@@ -68,11 +62,6 @@ on:
         required: false
       ARTIFACT_REPOSITORIES_SECRET_5:
         required: false
-
-env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
 
 jobs:
   plan_apply:
@@ -127,6 +116,18 @@ jobs:
         ARTIFACT_REPOSITORIES_SECRET_3: ${{ secrets.ARTIFACT_REPOSITORIES_SECRET_3 }}
         ARTIFACT_REPOSITORIES_SECRET_4: ${{ secrets.ARTIFACT_REPOSITORIES_SECRET_4 }}
         ARTIFACT_REPOSITORIES_SECRET_5: ${{ secrets.ARTIFACT_REPOSITORIES_SECRET_5 }}
+
+    - if: ${{ github.event_name == 'pull_request' }}
+      uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+      with:
+        role-to-assume: arn:aws:iam::323258989788:role/hub-roles/github+${{ github.repository_owner }}+${{ github.event.repository.name }}+repo
+        aws-region: us-east-1
+
+    - if: ${{ github.event_name != 'pull_request' }}
+      uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+      with:
+        role-to-assume: arn:aws:iam::323258989788:role/hub-roles/github+${{ github.repository_owner }}+${{ github.event.repository.name }}+repo
+        aws-region: us-east-1
 
     - id: plan
       uses: Brightspace/terraform-workflows/actions/plan@v4

--- a/.github/workflows/workflow-autoapply.yml
+++ b/.github/workflows/workflow-autoapply.yml
@@ -72,7 +72,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      issues: write
+      pull-requests: write
 
     environment: ${{ github.event_name != 'pull_request' && matrix.environment || null }}
     # Workflows against a branch run one-at-a-time, workflows against a PR are non-blocking

--- a/.github/workflows/workflow-autoapply.yml
+++ b/.github/workflows/workflow-autoapply.yml
@@ -69,6 +69,11 @@ jobs:
     runs-on: [self-hosted, Linux, AWS]
     timeout-minutes: 60
 
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+
     environment: ${{ github.event_name != 'pull_request' && matrix.environment || null }}
     # Workflows against a branch run one-at-a-time, workflows against a PR are non-blocking
     concurrency: ${{ matrix.environment }}/${{ github.event_name != 'pull_request' && github.ref || github.run_id }}

--- a/.github/workflows/workflow-autoapply.yml
+++ b/.github/workflows/workflow-autoapply.yml
@@ -123,12 +123,14 @@ jobs:
         ARTIFACT_REPOSITORIES_SECRET_5: ${{ secrets.ARTIFACT_REPOSITORIES_SECRET_5 }}
 
     - if: ${{ github.event_name == 'pull_request' }}
+      name: Assume Hub Role (PR)
       uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
       with:
         role-to-assume: arn:aws:iam::323258989788:role/hub-roles/github+${{ github.repository_owner }}+${{ github.event.repository.name }}+repo
         aws-region: us-east-1
 
     - if: ${{ github.event_name != 'pull_request' }}
+      name: Assume Hub Role
       uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
       with:
         role-to-assume: arn:aws:iam::323258989788:role/hub-roles/github+${{ github.repository_owner }}+${{ github.event.repository.name }}+repo

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -58,12 +58,6 @@ on:
         value: ${{ toJson(jobs.plan.outputs.*) != '[]' }}
 
     secrets:
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      AWS_SESSION_TOKEN:
-        required: true
       ARTIFACT_REPOSITORIES_SECRET_1:
         required: false
       ARTIFACT_REPOSITORIES_SECRET_2:
@@ -76,11 +70,6 @@ on:
         required: false
       D2L_SLACK_TOKEN:
         required: false
-
-env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
 
 jobs:
   plan:
@@ -133,6 +122,11 @@ jobs:
         ARTIFACT_REPOSITORIES_SECRET_3: ${{ secrets.ARTIFACT_REPOSITORIES_SECRET_3 }}
         ARTIFACT_REPOSITORIES_SECRET_4: ${{ secrets.ARTIFACT_REPOSITORIES_SECRET_4 }}
         ARTIFACT_REPOSITORIES_SECRET_5: ${{ secrets.ARTIFACT_REPOSITORIES_SECRET_5 }}
+
+    - uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+      with:
+        role-to-assume: arn:aws:iam::323258989788:role/hub-roles/github+${{ github.repository_owner }}+${{ github.event.repository.name }}+repo
+        aws-region: us-east-1
 
     - id: plan
       uses: Brightspace/terraform-workflows/actions/plan@v4
@@ -256,6 +250,11 @@ jobs:
         config: ${{ toJson(fromJson(inputs.config)) }}
 
     - uses: Brightspace/third-party-actions@actions/checkout
+
+    - uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+      with:
+        role-to-assume: arn:aws:iam::323258989788:role/hub-roles/github+${{ github.repository_owner }}+${{ github.event.repository.name }}+tfapply
+        aws-region: us-east-1
 
     - uses: Brightspace/terraform-workflows/actions/apply@v4
       with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -128,7 +128,8 @@ jobs:
         ARTIFACT_REPOSITORIES_SECRET_4: ${{ secrets.ARTIFACT_REPOSITORIES_SECRET_4 }}
         ARTIFACT_REPOSITORIES_SECRET_5: ${{ secrets.ARTIFACT_REPOSITORIES_SECRET_5 }}
 
-    - uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+    - name: Assume Hub Role
+      uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
       with:
         role-to-assume: arn:aws:iam::323258989788:role/hub-roles/github+${{ github.repository_owner }}+${{ github.event.repository.name }}+repo
         aws-region: us-east-1
@@ -260,7 +261,8 @@ jobs:
 
     - uses: Brightspace/third-party-actions@actions/checkout
 
-    - uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+    - name: Assume Hub Role
+      uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
       with:
         role-to-assume: arn:aws:iam::323258989788:role/hub-roles/github+${{ github.repository_owner }}+${{ github.event.repository.name }}+tfapply
         aws-region: us-east-1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -80,7 +80,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      issues: write
+      pull-requests: write
 
     environment: ${{ github.event_name != 'pull_request' && 'preflight' || null }}
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -77,6 +77,11 @@ jobs:
     runs-on: [self-hosted, Linux, AWS]
     timeout-minutes: 60
 
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+
     environment: ${{ github.event_name != 'pull_request' && 'preflight' || null }}
 
     strategy:
@@ -231,6 +236,10 @@ jobs:
     needs: plan
 
     if: github.event_name != 'pull_request' && toJson(needs.plan.outputs.*) != '[]'
+
+    permissions:
+      contents: read
+      id-token: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Uses OIDC to assume the hub role, rather than relying on the secrets being passed in. Should alleviate any issues of the token expiring while Apply is waiting for approval. Could also wire up disabling rotations of the `+tfapply` role to reduce our load on that end.