### PR TITLE
add action:read to permissions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -78,6 +78,7 @@ jobs:
     timeout-minutes: 60
 
     permissions:
+      actions: read
       contents: read
       id-token: write
       pull-requests: write
@@ -247,6 +248,7 @@ jobs:
     if: github.event_name != 'pull_request' && toJson(needs.plan.outputs.*) != '[]'
 
     permissions:
+      actions: read
       contents: read
       id-token: write
 


### PR DESCRIPTION
The Slack actions need `action: read` to get the correct job URL.

https://github.com/Brightspace/terraform-workflows/blob/7cfd71b8ddc148019a23c823ac3aa8669c8bea15/actions/plan/slack/send-plan-notification.sh#L5-L7

https://github.com/Brightspace/terraform-workflows/blob/7cfd71b8ddc148019a23c823ac3aa8669c8bea15/actions/apply/slack/send-apply-notification.sh#L5-L7
