### PR TITLE
Remove unbound error when notifying for bot

### DIFF
--- a/actions/plan/slack/get-slack-user.sh
+++ b/actions/plan/slack/get-slack-user.sh
@@ -27,6 +27,8 @@ if [ -n "${D2L_EMAIL}" ]; then
 		--header "Authorization: Bearer ${SLACK_TOKEN}" \
 		"https://slack.com/api/users.lookupByEmail?email=${D2L_EMAIL}" \
 		| jq '.user.id' --raw-output)"
+else
+	SLACK_USER_ID=""
 fi
 
 if [ -n "${SLACK_USER_ID}" ]; then


### PR DESCRIPTION
Noticed this during a [recent run](https://github.com/Brightspace/test-reporting-infrastructure/actions/runs/13038924558/job/36375988685#step:11:32). This prevents it sending a slack notification for bot users. This should eliminate the error and allow it to post.

