### PR TITLE
INFR-87: Adding a reusable Terraform Test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,17 @@ on:
         type: string
         required: true
 
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        description: AWS Access Key ID
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        description: AWS Secret Access Key
+        required: true
+      AWS_SESSION_TOKEN:
+        description: AWS Session Token
+        required: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Example use: https://github.com/Brightspace/cm-protected-b/pull/62

I'm using the matrix approach because I want failures to quickly identify which module failed. Trade-offs include that it's verbose, that it uses a lot of runners, and that there's an extra "Find Modules" job in the mix.

Alternately I could have a single job with one step that tests all the modules and you have to check the logs to see what failed.

Tasks:
- [x] https://github.com/Brightspace/terraform-workflows/pull/65#discussion_r2289314537 (deferred based on https://github.com/Brightspace/terraform-workflows/pull/65#discussion_r2289319169)