### PR TITLE
IT-3795 let the draft state of the fmt PR be controllable

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -57,9 +57,10 @@ jobs:
         uses: Brightspace/third-party-actions@actions/github-script
         env:
           BRANCH_NAME: ${{ steps.format.outputs.format_branch }}
+          CREATE_PR_DRAFT: ${{ inputs.create_pr_draft }}
         with:
           script: |
-            const { BRANCH_NAME } = process.env
+            const { BRANCH_NAME, CREATE_PR_DRAFT } = process.env
             const { data: newPr } = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -67,7 +68,7 @@ jobs:
               body: `Auto format #${context.payload.number}`,
               head: BRANCH_NAME,
               base: context.payload.pull_request.head.ref,
-              draft: ${{ inputs.create_pr_draft }}
+              draft: CREATE_PR_DRAFT === 'true'
             });
             await github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,6 +13,12 @@ on:
         type: string
         required: true
 
+      create_pr_draft:
+        description: Whether the format-fixing PR should be opened as a draft
+        type: boolean
+        required: false
+        default: true
+
 jobs:
   format:
     name: Format
@@ -61,7 +67,7 @@ jobs:
               body: `Auto format #${context.payload.number}`,
               head: BRANCH_NAME,
               base: context.payload.pull_request.head.ref,
-              draft: true
+              draft: ${{ inputs.create_pr_draft }}
             });
             await github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
Added a new (optional) boolean input parameter `create_pr_draft` to the workflow, allowing users to specify whether the format-fixing PR should be opened as a draft. The default is set to `true`.