### PR TITLE
support not cancelling existing pending runs

### DIFF
--- a/.github/workflows/workflow-autoapply.yml
+++ b/.github/workflows/workflow-autoapply.yml
@@ -95,7 +95,7 @@ jobs:
         case(
           inputs.cancel_pending_runs,
           '"{0}/{1}"',
-          '{"group":"{0}/{1}", "queue":"max"}'
+          '{{"group":"{0}/{1}", "queue":"max"}}'
         ),
         matrix.key || matrix.environment,
         case(github.event_name != 'pull_request', github.ref, github.run_id)

--- a/.github/workflows/workflow-autoapply.yml
+++ b/.github/workflows/workflow-autoapply.yml
@@ -53,6 +53,14 @@ on:
         required: false
         type: string
 
+      cancel_pending_runs:
+        description: |
+          If true (default), existing pending runs for the same workspace will be cancelled when this workflow is triggered.
+          If false, existing pending runs will not be cancelled, and the current run will be queued after them.
+        required: false
+        type: boolean
+        default: true
+
     outputs:
       had_changes:
         value: ${{ toJson(jobs.plan_apply.outputs.*) != '[]' }}
@@ -82,7 +90,16 @@ jobs:
 
     environment: ${{ github.event_name != 'pull_request' && matrix.environment || null }}
     # Workflows against a branch run one-at-a-time, workflows against a PR are non-blocking
-    concurrency: ${{ matrix.key || matrix.environment }}/${{ github.event_name != 'pull_request' && github.ref || github.run_id }}
+    concurrency: >-
+      ${{ fromJson(format(
+        case(
+          inputs.cancel_pending_runs,
+          '"{0}/{1}"',
+          '{"group":"{0}/{1}", "queue":"max"}'
+        ),
+        matrix.key || matrix.environment,
+        case(github.event_name != 'pull_request', github.ref, github.run_id)
+      )) }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Brand new GitHub feature supporting infinite queueing for a given concurrency group:
https://github.com/community/community/discussions/12835#discussioncomment-16602100

This is relevant in our OpenSearch repo, where our end-to-end testing workflow is sharing the same concurrency group with the Terraform workflow in the test environment, because we don't want TF to change the infra when tests are running.
This behaviour of always cancelling pending runs has caused pains because tests (or TF) would get cancelled when they don't need to and shouldn't be cancelled.

Only supporting this new queueing behaviour for the autoapply workflow. Don't think this makes a lot of sense with manual approval, because you can easily get many stale TF plans.

[HOD-4488 - update CI concurrency groups to use queue:max where appropriate](https://desire2learn.atlassian.net/browse/HOD-4488)