### PR TITLE
feat: add optional override for Terraform parallelism flag

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,6 +33,11 @@ on:
         default: 60
         type: number
 
+      parallelism:
+        description: Value passed to terraform's -parallelism flag during plan and apply. If unset, the flag is omitted and Terraform's own default is used.
+        required: false
+        type: number
+
       require_lockfile:
         description: Fail the workflow if the .terraform.lock.hcl file doesn't declare all providers in the workspace
         required: false
@@ -157,6 +162,7 @@ jobs:
         terraform_version: ${{ inputs.terraform_version }}
         refresh_on_pr: ${{ inputs.refresh_on_pr }}
         require_lockfile: ${{ inputs.require_lockfile }}
+        parallelism: ${{ inputs.parallelism }}
 
     - if: ${{ github.event_name != 'pull_request' && steps.plan.outputs.has_changes == 'true' && inputs.slack_channel != '' }}
       continue-on-error: true
@@ -443,7 +449,8 @@ jobs:
             "terraform_version": "${{ inputs.terraform_version }}",
             "environment": "${{ fromJson(matrix.workspace).environment }}",
             "key": "${{ fromJson(matrix.workspace).key }}",
-            "workspace_path": "${{ fromJson(steps.parse.outputs.config)[fromJson(matrix.workspace).key].workspace_path }}"
+            "workspace_path": "${{ fromJson(steps.parse.outputs.config)[fromJson(matrix.workspace).key].workspace_path }}",
+            "parallelism": "${{ inputs.parallelism }}"
           }
 
     - if: ${{ !cancelled() && inputs.slack_channel != '' }}

--- a/README.md
+++ b/README.md
@@ -194,6 +194,15 @@ Defaults to `false`.
 
 ---
 
+##### `parallelism` (`number`)
+
+**Optional**.
+The value to pass to terraform's `-parallelism` flag during `plan` and `apply`, controlling the number of concurrent resource operations.
+If unset, the flag is omitted entirely and Terraform's own default (currently `10`) is used, so behaviour is unaffected if you don't set this.
+Raising this can reduce deploy time for workspaces with a large number of resources (e.g. hundreds of `for_each`-managed resources), though returns diminish (or reverse) well beyond typical provider/API rate limits.
+
+---
+
 ##### `slack_channel` (`string`)
 
 **Optional**.

--- a/actions/apply/action.yml
+++ b/actions/apply/action.yml
@@ -28,3 +28,4 @@ runs:
         PLAN_PATH: ${{ steps.download.outputs.artifacts_dir }}/terraform.plan
         PLAN_ARTIFACTS: ${{ steps.download.outputs.artifacts_dir }}
         WORKSPACE_KEY: ${{ fromJson(inputs.config).key }}
+        PARALLELISM: ${{ fromJson(inputs.config).parallelism }}

--- a/actions/apply/apply.sh
+++ b/actions/apply/apply.sh
@@ -55,5 +55,10 @@ echo "##[group]terraform init"
 terraform init -input=false -backend-config="${BACKEND_CONFIG}"
 echo "##[endgroup]"
 
+PARALLELISM_FLAG=""
+if [ -n "${PARALLELISM:-}" ]; then
+	PARALLELISM_FLAG="-parallelism=${PARALLELISM}"
+fi
+
 terraform show "${PLAN_PATH}"
-terraform apply -input=false "${PLAN_PATH}"
+terraform apply -input=false ${PARALLELISM_FLAG} "${PLAN_PATH}"

--- a/actions/plan/action.yml
+++ b/actions/plan/action.yml
@@ -30,6 +30,9 @@ inputs:
     description: Fail the action if the .terraform.lock.hcl file doesn't declare all providers in the workspace
     default: false
 
+  parallelism:
+    description: Value passed to terraform's -parallelism flag during plan. If empty, the flag is omitted and Terraform's own default is used.
+
 outputs:
   plan_path:
     description: Path to plan file
@@ -68,6 +71,7 @@ runs:
         PROVIDER_ROLE_TFVAR: ${{ fromJson(inputs.config).provider_role_tfvar }}
         REFRESH_ON_PR: ${{ inputs.refresh_on_pr }}
         REQUIRE_LOCKFILE: ${{ inputs.require_lockfile }}
+        PARALLELISM: ${{ inputs.parallelism }}
 
     - run: ${{ github.action_path }}/details.sh
       shell: bash

--- a/actions/plan/plan.sh
+++ b/actions/plan/plan.sh
@@ -68,6 +68,11 @@ if [ "${REQUIRE_LOCKFILE}" == "true" ]; then
 	fi
 fi
 
+PARALLELISM_FLAG=""
+if [ -n "${PARALLELISM:-}" ]; then
+	PARALLELISM_FLAG="-parallelism=${PARALLELISM}"
+fi
+
 set +e
 echo "##[group]terraform plan"
 terraform plan \
@@ -76,7 +81,8 @@ terraform plan \
 	-detailed-exitcode \
 	-var "${PROVIDER_ROLE_TFVAR}=${PROVIDER_ROLE_ARN}" \
 	-out "${ARTIFACTS_DIR}/terraform.plan" \
-	${REFRESH}
+	${REFRESH} \
+	${PARALLELISM_FLAG}
 PLAN_EXIT_CODE=$?
 echo "##[endgroup]"
 


### PR DESCRIPTION
EAP-3167

Add optional parameter to allow passing `--parallelism` flag to Terraform.

The workflow had been calling Terraform without setting the `--parallelism` flag, resulting in always using Terraform's default concurrency of 10.

This adds an optional parameter. If the parameter is not used, no parallelism flag is used with Terraform, so the behaviour should be unchanged for all existing callers of this workflow.

## Testing
I worked with Claude Sonnet 5 agent to have it do the following:
- Confirmed backward compatibility: `parallelism` input has no default and is only threaded through as `-parallelism=<value>` when explicitly set — if omitted, the flag is left out entirely so Terraform's own default applies, identical to current behavior for all existing callers.
- `bash -n` syntax-checked the modified plan.sh and apply.sh — no errors.
- Manually exercised the new flag-building logic (`PARALLELISM_FLAG`) in isolation with both an empty and a set (`40`) value:
  - `PARALLELISM=""` → no `-parallelism` flag added
  - `PARALLELISM="40"` → `-parallelism=40` added
- Reviewed workflow.yml → `actions/plan@v4` → plan.sh and workflow.yml → `actions/apply@v4` → apply.sh plumbing end-to-end to confirm the input reaches both `terraform plan` and `terraform apply` invocations.

To be verified after this is merged: a real end-to-end run in a consuming repo via changes in `Brightspace/brightspace-analytics-platform` setting `parallelism: 40`) to confirm Terraform actually receives and applies the flag in a live plan/apply job.